### PR TITLE
Move towards 'object store' language

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,18 @@ code of conduct first.
       categories.has_many_through(:posts)
     }
 
-  # 4. Create a mapper by combining a connection and a configuration
+  # 4. Create an object store by combining a connection and a configuration
 
-  MAPPERS = Terrestrial.mappers(
+  OBJECT_STORE = Terrestrial.object_store(
     datastore: DB,
     mappings: MAPPINGS,
   )
 
-  ## You are not limted to one mapper configuration or one database connection.
-  ## To handle complex situations you may create several segregated mappings
-  ## for your separate aggregate roots, potentially utilising multiple
-  ## databases and different domain object classes/compositions.
+  ## You are not limted to one object store configuration or one database
+  ## connection. To handle complex situations you may create several segregated
+  ## mappings and object stores for your separate aggregate roots, potentially
+  ## utilising multiple databases and different domain object
+  ## classes/compositions.
 
   # 5. Create some objects
 
@@ -117,13 +118,13 @@ code of conduct first.
 
   # 6. Save them
 
-  MAPPERS[:users].save(user)
+  OBJECT_STORE[:users].save(user)
 
   ## Only the (aggregate) root object needs to be passed to the mapper.
 
   # 7. Query
 
-  user = MAPPERS[:users].where(id: "2f0f791c-47cf-4a00-8676-e582075bcd65").first
+  user = OBJECT_STORE[:users].where(id: "2f0f791c-47cf-4a00-8676-e582075bcd65").first
 
   # => #<struct User
   #  id="2f0f791c-47cf-4a00-8676-e582075bcd65",

--- a/features/example.feature
+++ b/features/example.feature
@@ -48,7 +48,7 @@ Feature: Basic setup
           database: ENV.fetch("PGDATABASE"),
         )
       """
-    And the associations are defined in the mapper configuration
+    And the associations are defined in the configuration
       """
         MAPPINGS = Terrestrial.config(DB)
           .setup_mapping(:users) { |users|
@@ -65,9 +65,9 @@ Feature: Basic setup
             categories.has_many_through(:posts)
           }
       """
-    And a mapper is instantiated
+    And a object store is instantiated
       """
-        MAPPERS = Terrestrial.mappers(
+        OBJECT_STORE = Terrestrial.object_store(
           datastore: DB,
           mappings: MAPPINGS,
         )
@@ -93,11 +93,11 @@ Feature: Basic setup
       """
     And the new graph is saved
       """
-        MAPPERS[:users].save(user)
+        OBJECT_STORE[:users].save(user)
       """
     And the following query is executed
       """
-        user = MAPPERS[:users].where(id: "2f0f791c-47cf-4a00-8676-e582075bcd65").first
+        user = OBJECT_STORE[:users].where(id: "2f0f791c-47cf-4a00-8676-e582075bcd65").first
       """
     Then the persisted user object is returned with lazy associations
       """

--- a/features/step_definitions/example_steps.rb
+++ b/features/step_definitions/example_steps.rb
@@ -6,11 +6,11 @@ Given(/^a database connection is established$/) do |code_sample|
   example_eval(code_sample)
 end
 
-Given(/^the associations are defined in the mapper configuration$/) do |code_sample|
+Given(/^the associations are defined in the configuration$/) do |code_sample|
   example_eval(code_sample)
 end
 
-Given(/^a mapper is instantiated$/) do |code_sample|
+Given(/^a object store is instantiated$/) do |code_sample|
   example_eval(code_sample)
 end
 

--- a/lib/terrestrial/relational_store.rb
+++ b/lib/terrestrial/relational_store.rb
@@ -1,9 +1,11 @@
 require "terrestrial/graph_serializer"
 require "terrestrial/graph_loader"
+require "terrestrial/short_inspection_string"
 
 module Terrestrial
-  class MapperFacade
+  class RelationalStore
     include Enumerable
+    include ShortInspectionString
 
     def initialize(mappings:, mapping_name:, datastore:, dataset:, load_pipeline:, dump_pipeline:)
       @mappings = mappings
@@ -132,6 +134,14 @@ module Terrestrial
         mappings: mappings,
         object_load_pipeline: load_pipeline,
       )
+    end
+
+    def inspectable_properties
+      [
+        :mapping_name,
+        :dataset,
+        :eager_load,
+      ]
     end
   end
 end

--- a/spec/config_override_spec.rb
+++ b/spec/config_override_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "ostruct"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
@@ -9,12 +9,12 @@ require "terrestrial"
 require "terrestrial/configurations/conventional_configuration"
 
 RSpec.describe "Configuration override" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
-  let(:mappers) {
-    Terrestrial.mappers(mappings: override_config, datastore: datastore)
+  let(:object_store) {
+    Terrestrial.object_store(mappings: override_config, datastore: datastore)
   }
 
   let(:override_config) {
@@ -26,7 +26,7 @@ RSpec.describe "Configuration override" do
   }
 
   let(:user) {
-    user_mapper.where(id: "users/1").first
+    object_store[:users].where(id: "users/1").first
   }
 
   context "override the root mapper factory" do
@@ -97,7 +97,7 @@ RSpec.describe "Configuration override" do
 
       it "maps data from the specified relation" do
         expect(
-          user_mapper.map(&:id)
+          object_store[:users].map(&:id)
         ).to eq(["users/1", "users/2", "users/3"])
       end
     end
@@ -184,10 +184,10 @@ RSpec.describe "Configuration override" do
     }
 
     it "provides access to the same data via the different configs" do
-      expect(mappers[:t1_users].first.id).to eq("users/1")
-      expect(mappers[:t1_users].first).to be_a(TypeOneUser)
-      expect(mappers[:t2_users].first.id).to eq("users/1")
-      expect(mappers[:t2_users].first).to be_a(TypeTwoUser)
+      expect(object_store[:t1_users].first.id).to eq("users/1")
+      expect(object_store[:t1_users].first).to be_a(TypeOneUser)
+      expect(object_store[:t2_users].first.id).to eq("users/1")
+      expect(object_store[:t2_users].first).to be_a(TypeTwoUser)
     end
   end
 end

--- a/spec/custom_serializers_spec.rb
+++ b/spec/custom_serializers_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 require "support/have_persisted_matcher"
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
@@ -9,11 +9,11 @@ require "terrestrial"
 require "terrestrial/configurations/conventional_configuration"
 
 RSpec.describe "Config override" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
-  let(:user) { user_mapper.where(id: "users/1").first }
+  let(:user) { object_store[:users].where(id: "users/1").first }
 
   context "with an object that has private fields" do
     let(:user_serializer) {
@@ -36,7 +36,7 @@ RSpec.describe "Config override" do
         user.first_name = "This won't work"
         user.last_name = "because the serialzer is weird"
 
-        user_mapper.save(user)
+        object_store[:users].save(user)
 
         expect(datastore).to have_persisted(:users, hash_including(
           id: user.id,

--- a/spec/graph_traversal_spec.rb
+++ b/spec/graph_traversal_spec.rb
@@ -1,20 +1,20 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 
 RSpec.describe "Graph traversal" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
   describe "associations" do
-    subject(:mapper) { user_mapper }
+    subject(:user_store) { object_store[:users] }
 
     let(:user_query) {
-      mapper.where(id: "users/1")
+      user_store.where(id: "users/1")
     }
 
     let(:user) { user_query.first }

--- a/spec/new_graph_persistence_spec.rb
+++ b/spec/new_graph_persistence_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/have_persisted_matcher"
 
 RSpec.describe "Persist a new graph in empty datastore" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
 
   context "given a graph of new objects" do
     it "persists the root node" do
-      user_mapper.save(hansel)
+      object_store[:users].save(hansel)
 
       expect(datastore).to have_persisted(:users, {
         id: hansel.id,
@@ -20,7 +20,7 @@ RSpec.describe "Persist a new graph in empty datastore" do
     end
 
     it "persists one to many related nodes 1 level deep" do
-      user_mapper.save(hansel)
+      object_store[:users].save(hansel)
 
       expect(datastore).to have_persisted(:posts, hash_including(
         id: "posts/1",
@@ -39,7 +39,7 @@ RSpec.describe "Persist a new graph in empty datastore" do
 
     context "deep node with two foreign keys" do
       it "persists the node with both foreign keys" do
-        user_mapper.save(hansel)
+        object_store[:users].save(hansel)
 
         expect(datastore).to have_persisted(:comments, {
           id: "comments/1",
@@ -51,7 +51,7 @@ RSpec.describe "Persist a new graph in empty datastore" do
     end
 
     it "persists many to many related nodes" do
-      user_mapper.save(hansel)
+      object_store[:users].save(hansel)
 
       expect(datastore).to have_persisted(:categories, {
         id: "categories/1",
@@ -60,7 +60,7 @@ RSpec.describe "Persist a new graph in empty datastore" do
     end
 
     it "persists a 'join table' to faciliate many to many" do
-      user_mapper.save(hansel)
+      object_store[:users].save(hansel)
 
       expect(datastore).to have_persisted(:categories_to_posts, {
         category_id: "categories/1",

--- a/spec/object_identity_spec.rb
+++ b/spec/object_identity_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 
 RSpec.describe "Object identity" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
-  subject(:mapper) { mappers.fetch(:users) }
+  subject(:user_store) { object_store.fetch(:users) }
 
-  let(:user) { mapper.where(id: "users/1").first }
+  let(:user) { user_store.where(id: "users/1").first }
   let(:post) { user.posts.first }
 
   context "when using arbitrary where query" do
@@ -46,7 +46,7 @@ RSpec.describe "Object identity" do
     end
 
     context "when eager loading" do
-      let(:user_query) { mapper.where(id: "users/1") }
+      let(:user_query) { user_store.where(id: "users/1") }
 
       let(:eager_category) {
         user_query

--- a/spec/ordered_association_spec.rb
+++ b/spec/ordered_association_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 require "terrestrial/configurations/conventional_configuration"
 
 RSpec.describe "Ordered associations" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
   context "one to many association ordered by `created_at DESC`" do
-    let(:posts) { user_mapper.first.posts }
+    let(:posts) { object_store[:users].first.posts }
 
     before do
       configs.fetch(:users).fetch(:associations).fetch(:posts).merge!(
@@ -40,7 +40,7 @@ RSpec.describe "Ordered associations" do
       )
     end
 
-    let(:categories) { user_mapper.first.posts.first.categories }
+    let(:categories) { object_store[:users].first.posts.first.categories }
 
     it "enumerates the objects in order specified in the config" do
       expect(categories.map(&:id)).to eq(

--- a/spec/predefined_queries_spec.rb
+++ b/spec/predefined_queries_spec.rb
@@ -1,17 +1,17 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 require "terrestrial/configurations/conventional_configuration"
 
 RSpec.describe "Predefined subset queries" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
-  subject(:users) { user_mapper }
+  subject(:users) { object_store[:users] }
 
   context "on the top level mapper" do
     context "subset is defined with a block" do

--- a/spec/proxying_spec.rb
+++ b/spec/proxying_spec.rb
@@ -1,22 +1,17 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 
 RSpec.describe "Proxying associations" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
   context "of type `has_many`" do
-    subject(:mapper) { user_mapper }
-
-    let(:user) {
-      mapper.where(id: "users/1").first
-    }
-
+    let(:user) { object_store[:users].where(id: "users/1").first }
     let(:posts) { user.posts }
 
     describe "limiting datastore reads" do

--- a/spec/querying_spec.rb
+++ b/spec/querying_spec.rb
@@ -1,19 +1,19 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 
 RSpec.describe "Querying" do
-  include_context "mapper setup"
+  include_context "object store setup"
   include_context "sequel persistence setup"
   include_context "seed data setup"
 
-  subject(:mapper) { user_mapper }
+  subject(:user_store) { object_store[:users] }
 
   let(:user) {
-    mapper.where(id: "users/1").first
+    user_store.where(id: "users/1").first
   }
 
   let(:query_criteria) {

--- a/spec/readme_examples_spec.rb
+++ b/spec/readme_examples_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"
 
 require "spec_helper"
 
-require "support/mapper_setup"
+require "support/object_store_setup"
 require "support/sequel_persistence_setup"
 require "support/seed_data_setup"
 require "terrestrial"

--- a/spec/support/object_store_setup.rb
+++ b/spec/support/object_store_setup.rb
@@ -1,5 +1,5 @@
 require "terrestrial"
-require "terrestrial/mapper_facade"
+require "terrestrial/relational_store"
 require "terrestrial/relation_mapping"
 require "terrestrial/lazy_collection"
 require "terrestrial/collection_mutability_proxy"
@@ -12,14 +12,14 @@ require "terrestrial/many_to_many_association"
 require "terrestrial/subset_queries_proxy"
 require "support/object_graph_setup"
 
-RSpec.shared_context "mapper setup" do
+RSpec.shared_context "object store setup" do
   include_context "object graph setup"
 
-  let(:mappers) {
-    Terrestrial.mappers(mappings: mappings, datastore: datastore)
+  let(:object_store) {
+    Terrestrial.object_store(mappings: mappings, datastore: datastore)
   }
 
-  let(:user_mapper) { mappers[:users] }
+  let(:user_store) { object_store[:users] }
 
   let(:mappings) {
     Hash[

--- a/spec/terrestrial/lazy_collection_spec.rb
+++ b/spec/terrestrial/lazy_collection_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Terrestrial::LazyCollection do
   let(:collection_size) { row_object_map.size }
 
   let(:database_enum) { [row1, row2].each.lazy }
-
   let(:mapper) { double(:mapper) }
 
   let(:loader_count) { @loader_count }

--- a/spec/terrestrial/lazy_collection_spec.rb
+++ b/spec/terrestrial/lazy_collection_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Terrestrial::LazyCollection do
     Terrestrial::LazyCollection.new(
       database_enum,
       loader,
-      mapper,
+      queries,
     )
   }
 
@@ -24,7 +24,7 @@ RSpec.describe Terrestrial::LazyCollection do
   let(:collection_size) { row_object_map.size }
 
   let(:database_enum) { [row1, row2].each.lazy }
-  let(:mapper) { double(:mapper) }
+  let(:queries) { {} }
 
   let(:loader_count) { @loader_count }
   let(:loader) {

--- a/spec/terrestrial/public_conveniencies_spec.rb
+++ b/spec/terrestrial/public_conveniencies_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Terrestrial::PublicConveniencies do
     end
   end
 
-  describe "#mappers" do
+  describe "#object_store" do
     let(:datastore) {
       MockDatastore.new(
         {
@@ -22,7 +22,7 @@ RSpec.describe Terrestrial::PublicConveniencies do
       )
     }
 
-    let(:mapper_config) {
+    let(:mappings) {
       {
         things: double(
           :thing_config,
@@ -44,14 +44,14 @@ RSpec.describe Terrestrial::PublicConveniencies do
       }
     }
 
-    it "returns a mapper for the specified mapping" do
-      mappers = conveniences.mappers(
-        mappings: mapper_config,
+    it "returns an object store for given mappings" do
+      object_store = conveniences.object_store(
+        mappings: mappings,
         datastore: datastore,
       )
 
       expect(
-        mappers[:things].all.first.fetch(:id)
+        object_store[:things].all.first.fetch(:id)
       ).to eq("THE THING")
     end
   end


### PR DESCRIPTION
The terms 'map' and 'mapper' have become over-used within this library.

Using the term object store instead gives a clearer impression of what
the top level abstraction provides.