### PR TITLE
Better factory error handling

### DIFF
--- a/lib/terrestrial/error.rb
+++ b/lib/terrestrial/error.rb
@@ -1,0 +1,3 @@
+module Terrestrial
+  Error = Module.new
+end

--- a/lib/terrestrial/error.rb
+++ b/lib/terrestrial/error.rb
@@ -1,3 +1,26 @@
 module Terrestrial
   Error = Module.new
+
+  class LoadError < RuntimeError
+    include Error
+
+    def initialize(relation_name, factory, record, original_error)
+      @relation_name = relation_name
+      @factory = factory
+      @record = record
+      @original_error = original_error
+    end
+
+    attr_reader :relation_name, :factory, :record, :original_error
+    private :relation_name, :factory, :record, :original_error
+
+    def message
+      [
+        "Error loading record from `#{relation_name}` relation `#{record.inspect}`.",
+        "Using: `#{factory.inspect}`.",
+        "Check that the factory is compatible.",
+        "Got Error: #{original_error.class.name} #{original_error.message}",
+      ].join("\n")
+    end
+  end
 end

--- a/lib/terrestrial/public_conveniencies.rb
+++ b/lib/terrestrial/public_conveniencies.rb
@@ -97,7 +97,7 @@ module Terrestrial
                 mapping.fields.include?(k)
               }
 
-              object = mapping.factory.call(attributes.merge(associated_fields))
+              object = mapping.load(attributes.merge(associated_fields))
               identity_map.call(mapping, record, object)
             },
           ].reduce(record) { |agg, operation|

--- a/lib/terrestrial/relation_mapping.rb
+++ b/lib/terrestrial/relation_mapping.rb
@@ -12,9 +12,14 @@ module Terrestrial
     end
 
     attr_reader :name, :namespace, :fields, :primary_key, :factory, :serializer, :associations, :subsets
+    private :factory
 
     def add_association(name, new_association)
       @associations = associations.merge(name => new_association)
+    end
+
+    def load(record)
+      factory.call(record)
     end
 
     def serialize(object, depth, foreign_keys = {})

--- a/lib/terrestrial/relation_mapping.rb
+++ b/lib/terrestrial/relation_mapping.rb
@@ -1,3 +1,5 @@
+require "terrestrial/error"
+
 module Terrestrial
   class RelationMapping
     def initialize(name:, namespace:, fields:, primary_key:, factory:, serializer:, associations:, subsets:)
@@ -20,6 +22,8 @@ module Terrestrial
 
     def load(record)
       factory.call(record)
+    rescue => e
+      raise LoadError.new(namespace, factory, record, e)
     end
 
     def serialize(object, depth, foreign_keys = {})

--- a/spec/factory_error_handling_spec.rb
+++ b/spec/factory_error_handling_spec.rb
@@ -1,0 +1,65 @@
+require "support/sequel_persistence_setup"
+
+require "terrestrial"
+require "terrestrial/configurations/conventional_configuration"
+
+RSpec.describe "factory error handling" do
+  include_context "sequel persistence setup"
+
+  context "factory with too few parameters" do
+    before do
+      seed_user(record)
+      override_user_factory_with(no_parameters_factory)
+    end
+
+    let(:record) {
+      {
+        id: "users/999",
+        first_name: "Badger",
+        last_name: "Smith",
+        email: "b@smith.biz",
+      }
+    }
+
+    let(:no_parameters_factory) {
+      ->() { }
+    }
+
+    it "raises a helpful error message" do
+      error = nil
+      begin
+        load_first_user
+      rescue Terrestrial::Error => error
+      end
+
+      expect(error.message).to eq(
+        [
+          "Error loading record from `users` relation `#{record.inspect}`.",
+          "Using: `#{no_parameters_factory.inspect}`.",
+          "Check that the factory is compatible.",
+          "Got Error: ArgumentError wrong number of arguments (given 1, expected 0)",
+        ].join("\n")
+      )
+    end
+  end
+
+  def load_first_user
+    @object_store[:users].first
+  end
+
+  def override_user_factory_with(factory)
+    config = Terrestrial.config(datastore)
+      .setup_mapping(:users) { |users|
+        users.factory(no_parameters_factory)
+      }
+
+    @object_store = Terrestrial.object_store(
+      mappings: config,
+      datastore: datastore,
+    )
+  end
+
+  def seed_user(record)
+    datastore[:users].insert(record)
+  end
+end

--- a/spec/terrestrial/public_conveniencies_spec.rb
+++ b/spec/terrestrial/public_conveniencies_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 require "terrestrial/public_conveniencies"
+require "ostruct"
 
 RSpec.describe Terrestrial::PublicConveniencies do
   subject(:conveniences) {
@@ -31,7 +32,7 @@ RSpec.describe Terrestrial::PublicConveniencies do
           fields: [:id],
           associations: [],
           primary_key: [],
-          factory: ->(x){x}
+          load: thing_object,
         )
       }
     }
@@ -44,6 +45,10 @@ RSpec.describe Terrestrial::PublicConveniencies do
       }
     }
 
+    let(:thing_object) {
+      OpenStruct.new(thing_record)
+    }
+
     it "returns an object store for given mappings" do
       object_store = conveniences.object_store(
         mappings: mappings,
@@ -51,7 +56,7 @@ RSpec.describe Terrestrial::PublicConveniencies do
       )
 
       expect(
-        object_store[:things].all.first.fetch(:id)
+        object_store[:things].all.first.id
       ).to eq("THE THING")
     end
   end


### PR DESCRIPTION
Just a small UX improvement!

Raise a `Terrestrial::LoadError` for failed loads, hopefully showing a more descriptive and useful message than the original error raised.

As part of this, hide `RelationMapping#factory` behind a `#load` method