### PR TITLE
Add objects to associated collections without mutation

### DIFF
--- a/lib/terrestrial/collection_mutability_proxy.rb
+++ b/lib/terrestrial/collection_mutability_proxy.rb
@@ -31,14 +31,15 @@ module Terrestrial
       end
     end
 
-    def delete(node)
-      @deleted_nodes.push(node)
+    def push(node)
+      force_load
+      added_nodes.push(node)
       self
     end
 
-    def push(node)
-      force_load
-      @added_nodes.push(node)
+    def delete(node)
+      deleted_nodes.push(node)
+      self
     end
 
     def _loaded_nodes
@@ -80,7 +81,7 @@ module Terrestrial
     end
 
     def deleted?(node)
-      @deleted_nodes.include?(node)
+      deleted_nodes.include?(node)
     end
   end
 end

--- a/lib/terrestrial/collection_mutability_proxy.rb
+++ b/lib/terrestrial/collection_mutability_proxy.rb
@@ -18,14 +18,6 @@ module Terrestrial
 
     def_delegators :collection, :where, :subset
 
-    def each_loaded(&block)
-      loaded_enum.each(&block)
-    end
-
-    def each_deleted(&block)
-      @deleted_nodes.each(&block)
-    end
-
     def to_ary
       to_a
     end
@@ -47,6 +39,14 @@ module Terrestrial
     def push(node)
       force_load
       @added_nodes.push(node)
+    end
+
+    def _loaded_nodes
+      loaded_enum.each
+    end
+
+    def _deleted_nodes
+      deleted_nodes.each
     end
 
     private

--- a/lib/terrestrial/collection_mutability_proxy.rb
+++ b/lib/terrestrial/collection_mutability_proxy.rb
@@ -7,10 +7,10 @@ module Terrestrial
     include ShortInspectionString
     include Enumerable
 
-    def initialize(collection)
+    def initialize(collection, added_nodes: [], deleted_nodes: [])
       @collection = collection
-      @added_nodes = []
-      @deleted_nodes = []
+      @added_nodes = added_nodes
+      @deleted_nodes = deleted_nodes
     end
 
     attr_reader :collection, :deleted_nodes, :added_nodes
@@ -48,6 +48,24 @@ module Terrestrial
 
     def _deleted_nodes
       deleted_nodes.each
+    end
+
+    def +(additional_nodes)
+      force_load
+
+      self.class.new(
+        collection,
+        added_nodes: added_nodes + additional_nodes,
+        deleted_nodes: deleted_nodes.dup,
+      )
+    end
+
+    def -(subtracted_nodes)
+      self.class.new(
+        collection,
+        added_nodes: added_nodes.dup,
+        deleted_nodes: deleted_nodes + subtracted_nodes,
+      )
     end
 
     private

--- a/lib/terrestrial/graph_serializer.rb
+++ b/lib/terrestrial/graph_serializer.rb
@@ -74,8 +74,8 @@ module Terrestrial
     end
 
     def get_loaded(collection)
-      if collection.respond_to?(:each_loaded)
-        collection.each_loaded
+      if collection.respond_to?(:_loaded_nodes)
+        collection._loaded_nodes
       elsif collection.is_a?(Struct)
         [collection]
       elsif collection.respond_to?(:each)
@@ -88,8 +88,8 @@ module Terrestrial
     end
 
     def get_deleted(collection)
-      if collection.respond_to?(:each_deleted)
-        collection.each_deleted
+      if collection.respond_to?(:_deleted_nodes)
+        collection._deleted_nodes
       else
         []
       end

--- a/spec/graph_persistence_spec.rb
+++ b/spec/graph_persistence_spec.rb
@@ -146,14 +146,28 @@ RSpec.describe "Graph persistence" do
     end
 
     context "when the collection is not loaded until the new object is persisted" do
-      it "is consistent with the datastore" do
-        user.posts.push(new_post)
+      context "when using collection push" do
+        it "is consistent with the datastore" do
+          user.posts.push(new_post)
 
-        user_store.save(user)
+          user_store.save(user)
 
-        expect(user.posts.to_a.map(&:id)).to eq(
-          ["posts/1", "posts/2", "posts/neu"]
-        )
+          expect(user.posts.to_a.map(&:id)).to eq(
+            ["posts/1", "posts/2", "posts/neu"]
+          )
+        end
+      end
+
+      context "when using collection +" do
+        it "is consistent with the datastore" do
+          user.posts = user.posts + [new_post]
+
+          user_store.save(user)
+
+          expect(user.posts.to_a.map(&:id)).to eq(
+            ["posts/1", "posts/2", "posts/neu"]
+          )
+        end
       end
     end
   end

--- a/spec/immutable_domain_objects_spec.rb
+++ b/spec/immutable_domain_objects_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+require "support/have_persisted_matcher"
+require "support/object_store_setup"
+require "support/sequel_persistence_setup"
+require "support/seed_data_setup"
+require "terrestrial"
+
+RSpec.describe "immutable domain objects" do
+  include_context "object store setup"
+  include_context "sequel persistence setup"
+  include_context "seed data setup"
+
+  let(:user) { object_store[:users].where(id: "users/1").first }
+  let(:user_clone) { user.clone }
+
+  context "update the root node" do
+    let(:modified_email) { "bestie+modified@gmail.com" }
+
+    it "persists the change" do
+      user_clone.email = modified_email
+      user_store.save(user_clone)
+
+      expect(datastore).to have_persisted(
+        :users,
+        hash_including(
+          id: "users/1",
+          email: modified_email,
+        )
+      )
+    end
+  end
+
+  context "add a node to a has many association" do
+    let(:new_post_attrs) {
+      {
+        id: "posts/neu",
+        subject: "I am new",
+        body: "new body",
+        comments: [],
+        categories: [],
+        created_at: Time.now,
+      }
+    }
+
+    let(:new_post) {
+      Post.new(new_post_attrs)
+    }
+
+    it "does not add the object to the graph" do
+      user.posts + [new_post]
+
+      expect(user.posts).not_to include(new_post)
+    end
+
+    it "persists the object" do
+      new_posts = user.posts + [new_post]
+      user_clone.posts = new_posts
+
+      user_store.save(user_clone)
+
+      expect(datastore).to have_persisted(
+        :posts,
+        hash_including(
+          id: "posts/neu",
+          author_id: user.id,
+          subject: "I am new",
+        )
+      )
+    end
+  end
+end

--- a/spec/terrestrial/collection_mutability_proxy_spec.rb
+++ b/spec/terrestrial/collection_mutability_proxy_spec.rb
@@ -154,6 +154,138 @@ RSpec.describe Terrestrial::CollectionMutabilityProxy do
     end
   end
 
+  describe "#+" do
+    let(:additional_nodes) { [10, 11, 12] }
+
+    it "returns a new collection" do
+      expect(proxy + additional_nodes).to be_a(Terrestrial::CollectionMutabilityProxy)
+      expect(proxy + additional_nodes).not_to be(proxy)
+      expect(proxy + additional_nodes).not_to be(additional_nodes)
+    end
+
+    it "concatenates with self" do
+      expect(
+        (proxy + additional_nodes).to_a
+      ).to eq([0,1,2,3,4,5,6,7,8,9,10,11,12])
+    end
+
+    it "does not mutate self" do
+      expect {
+        proxy + additional_nodes
+      }.not_to change { proxy.to_a }
+    end
+
+    context "after pushing a node" do
+      before do
+        proxy.push(pushed_node)
+      end
+
+      let(:pushed_node) { 99 }
+
+      it "retains the pushed nodes" do
+        expect(proxy + additional_nodes).to include(pushed_node)
+      end
+    end
+
+    context "after deleting a node" do
+      before do
+        proxy.delete(deleted_node)
+      end
+
+      let(:deleted_node) { 9 }
+
+      it "retains the deletion of the nodes" do
+        expect((proxy + additional_nodes).to_a).not_to include(deleted_node)
+      end
+    end
+
+    context "push to the original after adding" do
+      it "does not change the new collection" do
+        new_collection = proxy + additional_nodes
+
+        expect {
+          proxy.push(99)
+        }.not_to change { new_collection.to_a }
+      end
+    end
+
+    context "delete from the original after adding" do
+      it "does not change the new collection" do
+        new_collection = proxy + additional_nodes
+
+        expect {
+          proxy.delete(0)
+        }.not_to change { new_collection.to_a }
+      end
+    end
+  end
+
+  describe "#-" do
+    let(:subtracted_nodes) { [4, 6, 8, 9, 0] }
+
+    it "returns a new collection" do
+      expect(proxy - subtracted_nodes).to be_a(Terrestrial::CollectionMutabilityProxy)
+      expect(proxy - subtracted_nodes).not_to be(proxy)
+      expect(proxy - subtracted_nodes).not_to be(subtracted_nodes)
+    end
+
+    it "subtracts from self" do
+      expect(
+        (proxy - subtracted_nodes).to_a
+      ).to eq([1,2,3,5,7])
+    end
+
+    it "does not mutate self" do
+      expect {
+        proxy - subtracted_nodes
+      }.not_to change { proxy.to_a }
+    end
+
+    context "after pushing a node" do
+      before do
+        proxy.push(pushed_node)
+      end
+
+      let(:pushed_node) { 99 }
+
+      it "retains the pushed nodes" do
+        expect(proxy - subtracted_nodes).to include(pushed_node)
+      end
+    end
+
+    context "after deleting a node" do
+      before do
+        proxy.delete(deleted_node)
+      end
+
+      let(:deleted_node) { 2 }
+
+      it "retains the deletion of the nodes" do
+        expect((proxy - subtracted_nodes).to_a).not_to include(deleted_node)
+      end
+    end
+
+    context "push to the original after subtracting" do
+      it "does not change the new collection" do
+        new_collection = proxy - subtracted_nodes
+
+        expect {
+          proxy.push(99)
+        }.not_to change { new_collection.to_a }
+      end
+    end
+
+    context "delete from the original after subtracting" do
+      it "does not change the new collection" do
+        new_collection = proxy - subtracted_nodes
+
+        expect {
+          proxy.delete(1)
+        }.not_to change { new_collection.to_a }
+      end
+    end
+  end
+
   class LoadableCollectionDouble
     def initialize(collection, loaded_collection)
       @collection = collection


### PR DESCRIPTION
`CollectionMutabilityProxy` gains two methods `#+` and `#-`.
These behave much like the same methods on `Array` and return new
collection proxies with those elements added or removed respectively.

As with push the collection is loaded when adding nodes in order to
avoid inconsistencies when should the collection be loaded later.
